### PR TITLE
rowmajoriterator assignment overwrites referenced matrix

### DIFF
--- a/cpp/epidemiology/utils/eigen_util.h
+++ b/cpp/epidemiology/utils/eigen_util.h
@@ -222,8 +222,9 @@ template <class M, bool IsConst = false>
 class RowMajorIterator
 {
 public:
-    using MatrixReference = std::conditional_t<IsConst, const M&, M&>;
-    static_assert(IsConst || details::IsElementReference<MatrixReference>::value,
+    using MatrixRef = std::conditional_t<IsConst, const M&, M&>;
+    using MatrixPtr = std::conditional_t<IsConst, const M*, M*>;
+    static_assert(IsConst || details::IsElementReference<M>::value,
                   "Iterator must be const if matrix is not in memory.");
 
     using iterator_category = std::random_access_iterator_tag;
@@ -242,7 +243,7 @@ public:
             return &value;
         }
     };
-    using pointer = std::conditional_t<details::IsElementReference<MatrixReference>::value,
+    using pointer = std::conditional_t<details::IsElementReference<MatrixRef>::value,
                                        std::conditional_t<IsConst, const value_type*, value_type*>, Proxy>;
 
     /**
@@ -251,28 +252,11 @@ public:
      * @param m reference of a matrix expression. Only a reference is stored, mind the lifetime of the object.
      * @param i flat index of the element pointed to.
      */
-    RowMajorIterator(MatrixReference m, Eigen::Index i)
-        : m_matrix(m)
+    RowMajorIterator(MatrixRef m, Eigen::Index i)
+        : m_matrix(&m)
         , m_i(i)
     {
     }
-
-    /**
-     * Default copy constructor and copy assignment operator, default move constructor and move assignment operator
-     */
-    RowMajorIterator(const RowMajorIterator& other)
-        : m_matrix(other.m_matrix)
-        , m_i(other.m_i)
-    {
-    }
-    RowMajorIterator& operator=(const RowMajorIterator& other)
-    {
-        m_matrix = other.m_matrix;
-        m_i = other.m_i;
-        return *this;
-    };
-    RowMajorIterator(RowMajorIterator&&) = default;
-    RowMajorIterator& operator=(RowMajorIterator&&) = default;
 
     /**
      * pre increment operator.
@@ -296,14 +280,14 @@ public:
      */
     RowMajorIterator operator+(difference_type n) const
     {
-        return {const_cast<MatrixReference>(m_matrix), m_i + n};
+        return {*m_matrix, m_i + n};
     }
     /**
      * random access, add n to index of iterator.
      */
     friend RowMajorIterator operator+(difference_type n, const RowMajorIterator& iter)
     {
-        return {const_cast<MatrixReference>(iter.m_matrix), iter.m_i + n};
+        return {*iter.m_matrix, iter.m_i + n};
     }
     /**
      * add n to index of this.
@@ -335,7 +319,7 @@ public:
      */
     RowMajorIterator operator-(difference_type n) const
     {
-        return {const_cast<MatrixReference>(m_matrix), m_i - n};
+        return {*m_matrix, m_i - n};
     }
     /**
      * take n from the index of this.
@@ -360,7 +344,7 @@ public:
      */
     decltype(auto) operator*() const
     {
-        return m_matrix(m_i / m_matrix.cols(), m_i % m_matrix.cols());
+        return (*m_matrix)(m_i / m_matrix->cols(), m_i % m_matrix->cols());
     }
 
     /**
@@ -370,13 +354,13 @@ public:
      * The proxy stores a copy of the element and forwards the address of this copy.
      * @{
      */
-    template <class Dummy                                                        = MatrixReference,
+    template <class Dummy                                                        = MatrixRef,
               std::enable_if_t<details::IsElementReference<Dummy>::value, void*> = nullptr>
     pointer operator->() const
     {
         return &(**this);
     }
-    template <class Dummy                                                         = MatrixReference,
+    template <class Dummy                                                         = MatrixRef,
               std::enable_if_t<!details::IsElementReference<Dummy>::value, void*> = nullptr>
     pointer operator->() const
     {
@@ -428,7 +412,7 @@ public:
     }
 
 private:
-    MatrixReference m_matrix;
+    MatrixPtr m_matrix;
     Eigen::Index m_i;
 };
 

--- a/cpp/epidemiology/utils/eigen_util.h
+++ b/cpp/epidemiology/utils/eigen_util.h
@@ -205,12 +205,10 @@ auto map(const Rng& v, F f)
 namespace details
 {
     //true if elements returned by matrix(i, j) are references where matrix is of type M;
-    //false if the elements are temporaries, e.g. for expressions like Eigen::MatrixXd::Constant(r, c, v);
-    //Caution: This works only for matrix expressions having the LinearAccessBit:
-    // https://eigen.tuxfamily.org/dox/classEigen_1_1DenseCoeffsBase_3_01Derived_00_01ReadOnlyAccessors_01_4.html#a496672306836589fa04a6ab33cb0cf2a
+    //false if the elements are temporaries, e.g. for expressions like Eigen::MatrixXd::Constant(r, c, v).
     template <class M>
     using IsElementReference =
-        std::is_reference<decltype(std::declval<M>()[std::declval<Eigen::Index>()])>;
+        std::is_reference<decltype(std::declval<M>()(std::declval<Eigen::Index>(), std::declval<Eigen::Index>()))>;
 }
 
 /**


### PR DESCRIPTION
## Changes

- `RowMajorIterator` stores pointer to the matrix that is iterated over instead of a reference so that default copies and assignments of iterators are always shallow as intended
- Revert utility `IsElementReference` to check for operator `(i, j)` instead of operator `[i]`. The multi-index function call operator is more general and works for all matrix expressions. the check works fine in local gcc and msvc builds, CI, and compiler explorer, so I'm not sure what the issue was.

## Merge Request - GuideLine Checklist 

**Guideline** to check code before resolve WIP and approval, respectively.
As many checkboxes as possible should be ticked.

### Checks by code author:
* [x] There is at least one issue associated with the pull request.
* [x] The branch follows the naming conventions as defined in the [git workflow](git-workflow).
* [x] New code adheres with the [coding guidelines](coding-guidelines)
* [ ] Tests for new functionality has been added
* [x] A local test was succesful
* [ ] There is appropriate **documentation** of your work. (use doxygen style comments)
* [ ] If new third party software is used, did you pay attention to its license? Please remember to add it to the wiki after successful merging.
* [ ] If new mathematical methods or epidemiological terms are used, has the glossary been updated ? Did you provide further documentation ?
 is present or referenced. Please provide your references.
* [ ] The following questions are addressed in the documentation*:  Developers (what did you do?, how can it be maintained?), For users (how to use your work?), For admins (how to install and configure your work?)
* For documentation: Please write or update the Readme in the current working directory!

### Checks by code reviewer(s):
* [ ] Is the code clean of development artifacts e.g., unnecessary comments, prints, ...
* [ ] The ticket goals for each associated issue are reached or problems are clearly addressed (i.e., a new issue was introduced).
* [ ] There are appropriate **unit tests** and they pass.
* [ ] The git history is clean and linearized for the merge request.
* [ ] Coverage report for new code is acceptable. 

Closes #23 

