### PR TITLE
fix json serializer for 64 bit integers

### DIFF
--- a/cpp/memilio/io/json_serializer.h
+++ b/cpp/memilio/io/json_serializer.h
@@ -104,32 +104,34 @@ struct JsonType<T, std::enable_if_t<conjunction_v<is_small_integral<T>, std::is_
         return Json::Value(Json::UInt(i));
     }
 };
+template <class T>
+using is_64bit_integral = std::integral_constant<bool, (std::is_integral<T>::value && sizeof(T) == 8)>;
 //signed big ints
-template <>
-struct JsonType<int64_t> : std::true_type {
-    static IOResult<int64_t> transform(const Json::Value& js)
+template <class T>
+struct JsonType<T, std::enable_if_t<conjunction_v<is_64bit_integral<T>, std::is_signed<T>>>> : std::true_type {
+    static IOResult<T> transform(const Json::Value& js)
     {
         if (js.isInt64()) {
             return success(js.asInt64());
         }
         return failure(StatusCode::InvalidType, "Json value is not a 64 bit integer.");
     }
-    static Json::Value transform(int64_t i)
+    static Json::Value transform(T i)
     {
         return Json::Value(Json::Int64(i));
     }
 };
 //unsigned big ints
-template <>
-struct JsonType<uint64_t> : std::true_type {
-    static IOResult<uint64_t> transform(const Json::Value& js)
+template <class T>
+struct JsonType<T, std::enable_if_t<conjunction_v<is_64bit_integral<T>, std::is_unsigned<T>>>> : std::true_type {
+    static IOResult<T> transform(const Json::Value& js)
     {
         if (js.isUInt64()) {
             return success(js.asUInt64());
         }
         return failure(StatusCode::InvalidType, "Json value is not an unsigned 64bit integer.");
     }
-    static Json::Value transform(uint64_t i)
+    static Json::Value transform(T i)
     {
         return Json::Value(Json::UInt64(i));
     }


### PR DESCRIPTION
## Changes

Make `JsonSerializer` work for any 64 bit integer, not just `(u)int64_t`. 
`int64_t` only matches either long or long long, depending on the compiler.
Specialize `JsonType` for all 64 bit integer types using SFNIAE.

Closes #225 

## Merge Request - GuideLine Checklist 

**Guideline** to check code before resolve WIP and approval, respectively.
As many checkboxes as possible should be ticked.

### Checks by code author:
* [x] There is at least one issue associated with the pull request.
* [x] The branch follows the naming conventions as defined in the [git workflow](git-workflow).
* [x] New code adheres with the [coding guidelines](coding-guidelines)
* [ ] Tests for new functionality has been added
* [x] A local test was succesful
* [ ] There is appropriate **documentation** of your work. (use doxygen style comments)
* [ ] If new third party software is used, did you pay attention to its license? Please remember to add it to the wiki after successful merging.
* [ ] If new mathematical methods or epidemiological terms are used, has the glossary been updated ? Did you provide further documentation ?
 is present or referenced. Please provide your references.
* [ ] The following questions are addressed in the documentation*:  Developers (what did you do?, how can it be maintained?), For users (how to use your work?), For admins (how to install and configure your work?)
* For documentation: Please write or update the Readme in the current working directory!

### Checks by code reviewer(s):
* [ ] Is the code clean of development artifacts e.g., unnecessary comments, prints, ...
* [ ] The ticket goals for each associated issue are reached or problems are clearly addressed (i.e., a new issue was introduced).
* [ ] There are appropriate **unit tests** and they pass.
* [ ] The git history is clean and linearized for the merge request.
* [ ] Coverage report for new code is acceptable. 

