### PR TITLE
472 lcov code coverage drop correction

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # code coverage analysis
 # Note: this only works under linux and with make
 # Ninja creates different directory names which do not work together with this scrupt
+# as STREQUAL is case-sensitive https://github.com/TriBITSPub/TriBITS/issues/131, also allow DEBUG as accepted input
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     option(MEMILIO_TEST_COVERAGE "Enable GCov coverage analysis (adds a 'coverage' target)" OFF)
     mark_as_advanced(MEMILIO_TEST_COVERAGE)
@@ -33,7 +34,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         setup_target_for_coverage_lcov(
             NAME coverage
             EXECUTABLE memilio-test
-            EXCLUDE "${CMAKE_SOURCE_DIR}/tests*" "${CMAKE_SOURCE_DIR}/simulations*" "${CMAKE_SOURCE_DIR}/examples*" "${CMAKE_BINARY_DIR}/*" "/usr*"
+            EXCLUDE "${CMAKE_SOURCE_DIR}/tests*" "${CMAKE_SOURCE_DIR}/simulations*" "${CMAKE_SOURCE_DIR}/examples*" "${CMAKE_BINARY_DIR}/*" "/usr*" "/tools/*"
         )
     endif()
 endif()

--- a/cpp/tests/test_regions.cpp
+++ b/cpp/tests/test_regions.cpp
@@ -27,12 +27,19 @@ TEST(TestRegions, get_holidays)
     ASSERT_EQ(a.size(), 1);
     ASSERT_EQ(a[0], std::make_pair(mio::Date(2020, 10, 31), mio::Date(2020, 11, 7)));
 
-    auto b =
-        mio::regions::de::get_holidays(mio::regions::de::StateId(3), mio::Date(2020, 7, 30), mio::Date(2020, 12, 31));
-    ASSERT_EQ(b.size(), 3);
-    ASSERT_EQ(b[0], std::make_pair(mio::Date(2020, 7, 16), mio::Date(2020, 8, 27)));
-    ASSERT_EQ(b[1], std::make_pair(mio::Date(2020, 10, 12), mio::Date(2020, 10, 24)));
-    ASSERT_EQ(b[2], std::make_pair(mio::Date(2020, 12, 23), mio::Date(2021, 1, 9)));
+    ASSERT_EQ(
+        mio::regions::de::get_holidays(mio::regions::de::StateId(3), mio::Date(2020, 7, 30), mio::Date(2020, 12, 31))
+            .size(),
+        3);
+    ASSERT_EQ(mio::regions::de::get_holidays(mio::regions::de::StateId(3), mio::Date(2020, 7, 30),
+                                             mio::Date(2020, 12, 31))[0],
+              std::make_pair(mio::Date(2020, 7, 16), mio::Date(2020, 8, 27)));
+    ASSERT_EQ(mio::regions::de::get_holidays(mio::regions::de::StateId(3), mio::Date(2020, 7, 30),
+                                             mio::Date(2020, 12, 31))[1],
+              std::make_pair(mio::Date(2020, 10, 12), mio::Date(2020, 10, 24)));
+    ASSERT_EQ(mio::regions::de::get_holidays(mio::regions::de::StateId(3), mio::Date(2020, 7, 30),
+                                             mio::Date(2020, 12, 31))[2],
+              std::make_pair(mio::Date(2020, 12, 23), mio::Date(2021, 1, 9)));
 }
 
 TEST(TestRegions, get_state_id)


### PR DESCRIPTION
## Merge Request - GuideLine Checklist 

**Guideline** to check code before resolve WIP and approval, respectively.
As many checkboxes as possible should be ticked.

### Checks by code author:
Always to be checked:
* [x] There is at least one issue associated with the pull request.
* [x] The branch follows the naming conventions as defined in the [git workflow](git-workflow).
* [ ] New code adheres with the [coding guidelines](coding-guidelines)
* [ ] Make sure that the [pre-commit linting/style checks pass](https://github.com/DLR-SC/memilio/wiki).

If functions were changed or functionality was added:
* [ ] Tests for new functionality has been added
* [ ] A local test was succesful

If new functionality was added:
* [ ] There is appropriate **documentation** of your work. (use doxygen style comments)

If new third party software is used:
* [ ] Did you pay attention to its license? Please remember to add it to the wiki after successful merging.

If new mathematical methods or epidemiological terms are used:
* [ ] Are new methods referenced? Did you provide further documentation? Has the glossary been updated? 

The following questions are addressed in the documentation if need be: 
* [ ] Developers (what did you do?, how can it be maintained?)
* [ ] For users (how to use your work?)
* [ ] For admins (how to install and configure your work?)

* For documentation: Please write or update the Readme in the current working directory!

### Checks by code reviewer(s):
* [ ] Is the code clean of development artifacts e.g., unnecessary comments, prints, ...
* [ ] The ticket goals for each associated issue are reached or problems are clearly addressed (i.e., a new issue was introduced).
* [ ] There are appropriate **unit tests** and they pass.
* [ ] The git history is clean and linearized for the merge request. All reviewers should squash commits and write a simple and meaningful commit message.
* [ ] Coverage report for new code is acceptable. 

