### PR TITLE
512 add damping to secir_parameter_sampling example

### DIFF
--- a/cpp/examples/ode_secir_parameter_sampling.cpp
+++ b/cpp/examples/ode_secir_parameter_sampling.cpp
@@ -90,6 +90,12 @@ int main()
     params.get<mio::osecir::ContactPatterns>().get_dampings()[0].get_value().set_distribution(
         mio::ParameterDistributionNormal(0.0, 1.0, 0.5, 0.2));
 
+    params.get<mio::osecir::ContactPatterns>().get_dampings().push_back(mio::DampingSampling(
+        mio::UncertainValue(0.3), mio::DampingLevel(1), mio::DampingType(0), mio::SimulationTime(10.),
+        std::vector<size_t>(1, size_t(0)), Eigen::VectorXd::Constant(Eigen::Index(nb_groups.get()), 1.0)));
+    params.get<mio::osecir::ContactPatterns>().get_dampings()[0].get_value().set_distribution(
+        mio::ParameterDistributionNormal(0.0, 1.0, 0.4, 0.05));
+
     draw_sample(model);
     auto& cfmat_sample = params.get<mio::osecir::ContactPatterns>().get_cont_freq_mat();
 

--- a/cpp/examples/ode_secir_parameter_sampling.cpp
+++ b/cpp/examples/ode_secir_parameter_sampling.cpp
@@ -101,6 +101,7 @@ int main()
 
     printf("\n\n Number of dampings: %zu\n", cfmat_sample[0].get_dampings().size());
 
+    //Dampings are sorted automatically by time, therefore the second DampingSamping is at the first position
     printf("\n First damping at %.2f with factor %.2f\n", double(cfmat_sample[0].get_dampings()[0].get_time()),
            cfmat_sample[0].get_dampings()[0].get_coeffs()(0, 0));
 


### PR DESCRIPTION
## Merge Request - GuideLine Checklist 

**Guideline** to check code before resolve WIP and approval, respectively.
As many checkboxes as possible should be ticked.

### Checks by code author:
Always to be checked:
* [x] There is at least one issue associated with the pull request.
* [x] The branch follows the naming conventions as defined in the [git workflow](git-workflow).
* [x] New code adheres with the [coding guidelines](coding-guidelines)
* [x] Make sure that the [pre-commit linting/style checks pass](https://github.com/DLR-SC/memilio/wiki).

If functions were changed or functionality was added:
* [ ] Tests for new functionality has been added
* [x] A local test was succesful

If new functionality was added:
* [ ] There is appropriate **documentation** of your work. (use doxygen style comments)

If new third party software is used:
* [ ] Did you pay attention to its license? Please remember to add it to the wiki after successful merging.

If new mathematical methods or epidemiological terms are used:
* [ ] Are new methods referenced? Did you provide further documentation? Has the glossary been updated? 

The following questions are addressed in the documentation if need be: 
* [ ] Developers (what did you do?, how can it be maintained?)
* [ ] For users (how to use your work?)
* [ ] For admins (how to install and configure your work?)

* For documentation: Please write or update the Readme in the current working directory!

### Checks by code reviewer(s):
* [x] Is the code clean of development artifacts e.g., unnecessary comments, prints, ...
* [x] The ticket goals for each associated issue are reached or problems are clearly addressed (i.e., a new issue was introduced).
* [x] There are appropriate **unit tests** and they pass.
* [x] The git history is clean and linearized for the merge request. All reviewers should squash commits and write a simple and meaningful commit message.
* [x] Coverage report for new code is acceptable. 

