### PR TITLE
547 make path for coverage independent of python version

### DIFF
--- a/.github/actions/test-py/action.yml
+++ b/.github/actions/test-py/action.yml
@@ -37,7 +37,7 @@ runs:
       run: |
         cd pycode/memilio-${{inputs.package}}/memilio/${{inputs.package}}_test
         if [[ "${{ inputs.coverage }}" == "ON" ]]; then
-          python -W ignore::DeprecationWarning -m coverage run --include=*site-packages/memilio*,*dist-packages/memilio*,../../memilio* -m unittest
+          python -W ignore::DeprecationWarning -m coverage run --include=**site-packages/memilio* -m unittest
           python -m coverage report
           python -m coverage xml -o coverage_python.xml
           python -m coverage html -d coverage_python

--- a/.github/actions/test-py/action.yml
+++ b/.github/actions/test-py/action.yml
@@ -37,7 +37,7 @@ runs:
       run: |
         cd pycode/memilio-${{inputs.package}}/memilio/${{inputs.package}}_test
         if [[ "${{ inputs.coverage }}" == "ON" ]]; then
-          python -W ignore::DeprecationWarning -m coverage run --include=**/site-packages/memilio/* -m unittest
+          python -W ignore::DeprecationWarning -m coverage run --include=*site-packages/memilio*,*dist-packages/memilio*,../../memilio* -m unittest
           python -m coverage report
           python -m coverage xml -o coverage_python.xml
           python -m coverage html -d coverage_python

--- a/.github/actions/test-py/action.yml
+++ b/.github/actions/test-py/action.yml
@@ -37,7 +37,7 @@ runs:
       run: |
         cd pycode/memilio-${{inputs.package}}/memilio/${{inputs.package}}_test
         if [[ "${{ inputs.coverage }}" == "ON" ]]; then
-          python -W ignore::DeprecationWarning -m coverage run --include=**site-packages/memilio* -m unittest
+          python -W ignore::DeprecationWarning -m coverage run --include=**/site-packages/memilio/* -m unittest
           python -m coverage report
           python -m coverage xml -o coverage_python.xml
           python -m coverage html -d coverage_python

--- a/.github/actions/test-py/action.yml
+++ b/.github/actions/test-py/action.yml
@@ -37,7 +37,7 @@ runs:
       run: |
         cd pycode/memilio-${{inputs.package}}/memilio/${{inputs.package}}_test
         if [[ "${{ inputs.coverage }}" == "ON" ]]; then
-          python -W ignore::DeprecationWarning -m coverage run --source=/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/memilio/epidata -m unittest
+          python -W ignore::DeprecationWarning -m coverage run --include=**/site-packages/memilio/* -m unittest
           python -m coverage report
           python -m coverage xml -o coverage_python.xml
           python -m coverage html -d coverage_python

--- a/pycode/memilio-epidata/requirements-dev.txt
+++ b/pycode/memilio-epidata/requirements-dev.txt
@@ -1,5 +1,5 @@
 # dev dependencies, pyfakefs 4.2.0 is broken!
 pyfakefs==4.1.0
-coverage
+coverage>=7.0.1
 pylint<=2.11.1
 pylint_json2html<=0.3.0

--- a/pycode/memilio-epidata/setup.py
+++ b/pycode/memilio-epidata/setup.py
@@ -87,7 +87,8 @@ setup(
         'dev': [
             # smaller pyfakefs versions use deprecated functions for matplotlib versions >=3.4
             'pyfakefs>=4.2.1',
-            'coverage',
+            # coverage 7.0.0 can't find .whl files and breaks CI
+            'coverage>=7.0.1',
             'pylint<=2.11.1',
             'pylint_json2html<=0.3.0',
         ],


### PR DESCRIPTION
## Merge Request - GuideLine Checklist 

**Guideline** to check code before resolve WIP and approval, respectively.
As many checkboxes as possible should be ticked.

### Checks by code author:
Always to be checked:
* [x] There is at least one issue associated with the pull request.
* [x] The branch follows the naming conventions as defined in the [git workflow](git-workflow).
* [x] New code adheres with the [coding guidelines](coding-guidelines)
* [x] Make sure that the [pre-commit linting/style checks pass](https://github.com/DLR-SC/memilio/wiki).

If functions were changed or functionality was added:
* [ ] Tests for new functionality has been added
* [x] A local test was succesful

If new functionality was added:
* [ ] There is appropriate **documentation** of your work. (use doxygen style comments)

If new third party software is used:
* [ ] Did you pay attention to its license? Please remember to add it to the wiki after successful merging.

If new mathematical methods or epidemiological terms are used:
* [ ] Are new methods referenced? Did you provide further documentation? Has the glossary been updated? 

The following questions are addressed in the documentation if need be: 
* [ ] Developers (what did you do?, how can it be maintained?)
* [ ] For users (how to use your work?)
* [ ] For admins (how to install and configure your work?)

* For documentation: Please write or update the Readme in the current working directory!

### Checks by code reviewer(s):
* [ ] Is the code clean of development artifacts e.g., unnecessary comments, prints, ...
* [ ] The ticket goals for each associated issue are reached or problems are clearly addressed (i.e., a new issue was introduced).
* [ ] There are appropriate **unit tests** and they pass.
* [ ] The git history is clean and linearized for the merge request. All reviewers should squash commits and write a simple and meaningful commit message.
* [ ] Coverage report for new code is acceptable. 

