### PR TITLE
335 force shared libs for python bindings to fix set_log_level

### DIFF
--- a/pycode/memilio-simulation/setup.py
+++ b/pycode/memilio-simulation/setup.py
@@ -23,6 +23,7 @@ setup(
     packages=find_packages(
         where=os.path.dirname(os.path.abspath(__file__))),
     setup_requires=['cmake'],
+    cmake_args=['-DMEMILIO_BUILD_SHARED_LIBS:BOOL=ON'], #need shared libs so there is one shared log level
     install_requires=[],
     extras_require={'dev': ['numpy >= 1.22'], },
     long_description='', test_suite='memilio.simulation_test',)

--- a/pycode/memilio-simulation/setup.py
+++ b/pycode/memilio-simulation/setup.py
@@ -23,7 +23,8 @@ setup(
     packages=find_packages(
         where=os.path.dirname(os.path.abspath(__file__))),
     setup_requires=['cmake'],
-    cmake_args=['-DMEMILIO_BUILD_SHARED_LIBS:BOOL=ON'], #need shared libs so there is one shared log level
+    # need shared libs so there is one shared log level
+    cmake_args=['-DMEMILIO_BUILD_SHARED_LIBS:BOOL=ON'],
     install_requires=[],
     extras_require={'dev': ['numpy >= 1.22'], },
     long_description='', test_suite='memilio.simulation_test',)


### PR DESCRIPTION
## Changes

The problem to solve: If there are multiple shared objects/DLLs (either multiple python modules or one python module and the memilio libraries themselves) and spdlog is linked statically, there are multiple instances of the log level in each shared object. The set_log_level function in the memilio.simulation python bindings sets the log level in memilio.simulation shared object, but not in the memilio.simulation.secir shared object. So set_log_level doesn't work for secir simulations (or abm simulations or any other models that have their own shared object).

The quickest solution implemented here:
Set MEMILIO_BUILD_SHARED_LIBS=ON in setup.py to build memilio and dependencies as shared libraries when building python bindings so that there is exactly one stored instance of the log level. 
The log level is then stored exactly once in spdlog.so/dll and all logging references that.

Discussions of the drawbacks and alternative solutions and non-solutions below.

## Merge Request - GuideLine Checklist

- *Check our [git workflow](https://github.com/DLR-SC/memilio/wiki/git-workflow) before opening a Pull request/Merge request.*
- *Request a reviewer when your work is ready to review, before this please use the draft feature.*

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/DLR-SC/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes and code coverage is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)

### Additional context

Please list additional information or things a reviewer should look out for.

Closes #335 