### PR TITLE
728 reusing rkintegratorcore may cause crashes

### DIFF
--- a/cpp/memilio/math/adapt_rk.cpp
+++ b/cpp/memilio/math/adapt_rk.cpp
@@ -79,7 +79,7 @@ bool RKIntegratorCore::step(const DerivFunction& f, Eigen::Ref<const Eigen::Vect
     bool converged              = false; // carry for convergence criterion
     bool failed_step_size_adapt = false;
 
-    if (m_kt_values.size() == 0) {
+    if (m_yt_eval.size() != yt.size()) {
         m_yt_eval.resize(yt.size());
         m_kt_values.resize(yt.size(), m_tab_final.entries_low.size());
     }

--- a/cpp/memilio/math/adapt_rk.h
+++ b/cpp/memilio/math/adapt_rk.h
@@ -154,6 +154,7 @@ public:
     {
         m_tab       = tab;
         m_tab_final = final_tab;
+        m_kt_values.resize(Eigen::NoChange, m_tab_final.entries_low.size());
     }
 
     /**


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** made, additional Information and what the Reviewer should look out for:

- Resize internal variables of RKIntegratorCore when needed.

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/DLR-SC/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/DLR-SC/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added

### Checks by code reviewer(s)

- [ ] Corresponding issue(s) is/are linked and addressed
- [ ] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [ ] Appropriate **unit tests** have been added, CI passes and code coverage is acceptable (did not decrease)
- [ ] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)

Closes #728 