### PR TITLE
738 fix check constraints in parameters in IDE-SECIR 

### DIFF
--- a/cpp/models/ide_secir/model.h
+++ b/cpp/models/ide_secir/model.h
@@ -97,7 +97,7 @@ public:
                 "Initialization failed. Not enough time points for transitions given before start of simulation.");
         }
 
-        parameters.check_constraints(dt);
+        parameters.check_constraints();
     }
 
     /**

--- a/cpp/models/ide_secir/parameters.h
+++ b/cpp/models/ide_secir/parameters.h
@@ -173,8 +173,11 @@ public:
      */
     bool check_constraints() const
     {
-        size_t check_eval_min = 50; // parameter defining minimal window on x-axis
-        for (size_t i = 0; i < check_eval_min; i++) {
+        // For parameters potentially depending on the infectious age, values are checked
+        // equidistantly on a realistic maximum window.
+        // Please note that this is an incomplete check on correctness.
+        size_t infectious_window_check = 50; // parameter defining minimal window on x-axis
+        for (size_t i = 0; i < infectious_window_check; i++) {
             if (this->get<TransmissionProbabilityOnContact>().eval((ScalarType)i) < 0.0 ||
                 this->get<TransmissionProbabilityOnContact>().eval((ScalarType)i) > 1.0) {
                 log_error("Constraint check: TransmissionProbabilityOnContact smaller {:d} or larger {:d} at some "
@@ -184,7 +187,7 @@ public:
             }
         }
 
-        for (size_t i = 0; i < check_eval_min; i++) {
+        for (size_t i = 0; i < infectious_window_check; i++) {
             if (this->get<RelativeTransmissionNoSymptoms>().eval((ScalarType)i) < 0.0 ||
                 this->get<RelativeTransmissionNoSymptoms>().eval((ScalarType)i) > 1.0) {
                 log_error("Constraint check: RelativeTransmissionNoSymptoms smaller {:d} or larger {:d} at some "
@@ -194,7 +197,7 @@ public:
             }
         }
 
-        for (size_t i = 0; i < check_eval_min; i++) {
+        for (size_t i = 0; i < infectious_window_check; i++) {
             if (this->get<RiskOfInfectionFromSymptomatic>().eval((ScalarType)i) < 0.0 ||
                 this->get<RiskOfInfectionFromSymptomatic>().eval((ScalarType)i) > 1.0) {
                 log_error("Constraint check: RiskOfInfectionFromSymptomatic smaller {:d} or larger {:d} at some "

--- a/cpp/models/ide_secir/parameters.h
+++ b/cpp/models/ide_secir/parameters.h
@@ -171,12 +171,10 @@ public:
      * @param dt Time step size which is used to get model specific StateAgeFunction%s support.
      * @return Returns true if one (or more) constraint(s) are not satisfied, otherwise false.
      */
-    bool check_constraints(ScalarType dt = 0.1) const
+    bool check_constraints() const
     {
         size_t check_eval_min = 50; // parameter defining minimal window on x-axis
-        for (size_t i = 0;
-             i < std::min(check_eval_min, (size_t)this->get<TransmissionProbabilityOnContact>().get_support_max(dt));
-             i++) {
+        for (size_t i = 0; i < check_eval_min; i++) {
             if (this->get<TransmissionProbabilityOnContact>().eval((ScalarType)i) < 0.0 ||
                 this->get<TransmissionProbabilityOnContact>().eval((ScalarType)i) > 1.0) {
                 log_error("Constraint check: TransmissionProbabilityOnContact smaller {:d} or larger {:d} at some "
@@ -186,9 +184,7 @@ public:
             }
         }
 
-        for (size_t i = 0;
-             i < std::min(check_eval_min, (size_t)this->get<RelativeTransmissionNoSymptoms>().get_support_max(dt));
-             i++) {
+        for (size_t i = 0; i < check_eval_min; i++) {
             if (this->get<RelativeTransmissionNoSymptoms>().eval((ScalarType)i) < 0.0 ||
                 this->get<RelativeTransmissionNoSymptoms>().eval((ScalarType)i) > 1.0) {
                 log_error("Constraint check: RelativeTransmissionNoSymptoms smaller {:d} or larger {:d} at some "
@@ -198,9 +194,7 @@ public:
             }
         }
 
-        for (size_t i = 0;
-             i < std::min(check_eval_min, (size_t)this->get<RiskOfInfectionFromSymptomatic>().get_support_max(dt));
-             i++) {
+        for (size_t i = 0; i < check_eval_min; i++) {
             if (this->get<RiskOfInfectionFromSymptomatic>().eval((ScalarType)i) < 0.0 ||
                 this->get<RiskOfInfectionFromSymptomatic>().eval((ScalarType)i) > 1.0) {
                 log_error("Constraint check: RiskOfInfectionFromSymptomatic smaller {:d} or larger {:d} at some "


### PR DESCRIPTION
# Changes and Information

The check_constraints function in parameters used get_support_max for StateAgeFunctions in a wrong way. This is fixed here.

-

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/DLR-SC/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/DLR-SC/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes and code coverage is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)

Closes #738