### PR TITLE
779 increase tolerance for constraint checks to speed up tests

### DIFF
--- a/cpp/models/ode_secir/parameters.h
+++ b/cpp/models/ode_secir/parameters.h
@@ -411,7 +411,7 @@ public:
      */
     bool apply_constraints()
     {
-        double tol_times = 1e-4; // accepted tolerance for compartment stays
+        const double tol_times = 1e-1; // accepted tolerance for compartment stays
 
         int corrected = false;
         if (this->get<Seasonality>() < 0.0 || this->get<Seasonality>() > 0.5) {
@@ -550,7 +550,7 @@ public:
             return true;
         }
 
-        double tol_times = 1e-4; // accepted tolerance for compartment stays
+        const double tol_times = 1e-1; // accepted tolerance for compartment stays
 
         for (auto i = AgeGroup(0); i < AgeGroup(m_num_groups); ++i) {
 

--- a/cpp/models/ode_secirvvs/parameters.h
+++ b/cpp/models/ode_secirvvs/parameters.h
@@ -651,7 +651,7 @@ public:
             corrected = true;
         }
 
-        double tol_times = 1e-4; // accepted tolerance for compartment stays
+        const double tol_times = 1e-1; // accepted tolerance for compartment stays
 
         for (auto i = AgeGroup(0); i < AgeGroup(m_num_groups); ++i) {
 
@@ -850,7 +850,7 @@ public:
      */
     bool check_constraints() const
     {
-        double tol_times = 1e-4; // accepted tolerance for compartment stays
+        const double tol_times = 1e-1; // accepted tolerance for compartment stays
         if (this->get<Seasonality>() < 0.0 || this->get<Seasonality>() > 0.5) {
             log_error("Constraint check: Parameter m_seasonality smaller {:d} or larger {:d}", 0, 0.5);
             return true;

--- a/cpp/models/ode_seir/parameters.h
+++ b/cpp/models/ode_seir/parameters.h
@@ -123,7 +123,7 @@ public:
      */
     bool apply_constraints()
     {
-        double tol_times = 1e-4;
+        const double tol_times = 1e-1;
 
         int corrected = false;
         if (this->get<TimeExposed>() < tol_times) {
@@ -159,7 +159,7 @@ public:
      */
     bool check_constraints() const
     {
-        double tol_times = 1e-4;
+        const double tol_times = 1e-1;
 
         if (this->get<TimeExposed>() < tol_times) {
             log_error("Constraint check: Parameter TimeExposed {:.4f} smaller or equal {:.4f}. Please note that "

--- a/cpp/tests/test_odesecir.cpp
+++ b/cpp/tests/test_odesecir.cpp
@@ -858,8 +858,10 @@ TEST(Secir, check_constraints_parameters)
 
 TEST(Secir, apply_constraints_parameters)
 {
-    auto model         = mio::osecir::Model(1);
-    auto indx_agegroup = mio::AgeGroup(0);
+    auto model             = mio::osecir::Model(1);
+    auto indx_agegroup     = mio::AgeGroup(0);
+    const double tol_times = 1e-1;
+
     EXPECT_EQ(model.parameters.apply_constraints(), 0);
 
     mio::set_log_level(mio::LogLevel::off);
@@ -873,27 +875,27 @@ TEST(Secir, apply_constraints_parameters)
 
     model.parameters.set<mio::osecir::IncubationTime>(-2);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_EQ(model.parameters.get<mio::osecir::IncubationTime>()[indx_agegroup], 2e-4);
+    EXPECT_EQ(model.parameters.get<mio::osecir::IncubationTime>()[indx_agegroup], 2 * tol_times);
 
     model.parameters.set<mio::osecir::SerialInterval>(0);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_NEAR(model.parameters.get<mio::osecir::SerialInterval>()[indx_agegroup], 0.00015, 1e-14);
+    EXPECT_NEAR(model.parameters.get<mio::osecir::SerialInterval>()[indx_agegroup], 0.15, 1e-13);
 
     model.parameters.set<mio::osecir::SerialInterval>(5);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_NEAR(model.parameters.get<mio::osecir::SerialInterval>()[indx_agegroup], 0.00015, 1e-14);
+    EXPECT_NEAR(model.parameters.get<mio::osecir::SerialInterval>()[indx_agegroup], 0.15, 1e-13);
 
     model.parameters.set<mio::osecir::TimeInfectedSymptoms>(1e-8);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_EQ(model.parameters.get<mio::osecir::TimeInfectedSymptoms>()[indx_agegroup], 1e-4);
+    EXPECT_EQ(model.parameters.get<mio::osecir::TimeInfectedSymptoms>()[indx_agegroup], tol_times);
 
     model.parameters.set<mio::osecir::TimeInfectedSevere>(-1);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_EQ(model.parameters.get<mio::osecir::TimeInfectedSevere>()[indx_agegroup], 1e-4);
+    EXPECT_EQ(model.parameters.get<mio::osecir::TimeInfectedSevere>()[indx_agegroup], tol_times);
 
     model.parameters.set<mio::osecir::TimeInfectedCritical>(0);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_EQ(model.parameters.get<mio::osecir::TimeInfectedCritical>()[indx_agegroup], 1e-4);
+    EXPECT_EQ(model.parameters.get<mio::osecir::TimeInfectedCritical>()[indx_agegroup], tol_times);
 
     model.parameters.set<mio::osecir::TransmissionProbabilityOnContact>(2.0);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);

--- a/cpp/tests/test_odesecirvvs.cpp
+++ b/cpp/tests/test_odesecirvvs.cpp
@@ -1010,8 +1010,9 @@ TEST(TestOdeSECIRVVS, check_constraints_parameters)
 
 TEST(TestOdeSECIRVVS, apply_constraints_parameters)
 {
-    auto model         = mio::osecirvvs::Model(1);
-    auto indx_agegroup = mio::AgeGroup(0);
+    const double tol_times = 1e-1;
+    auto model             = mio::osecirvvs::Model(1);
+    auto indx_agegroup     = mio::AgeGroup(0);
     EXPECT_EQ(model.parameters.apply_constraints(), 0);
 
     mio::set_log_level(mio::LogLevel::off);
@@ -1026,27 +1027,27 @@ TEST(TestOdeSECIRVVS, apply_constraints_parameters)
 
     model.parameters.set<mio::osecirvvs::IncubationTime>(-2);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_EQ(model.parameters.get<mio::osecirvvs::IncubationTime>()[indx_agegroup], 2e-4);
+    EXPECT_EQ(model.parameters.get<mio::osecirvvs::IncubationTime>()[indx_agegroup], 2 * tol_times);
 
     model.parameters.set<mio::osecirvvs::SerialInterval>(0);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_NEAR(model.parameters.get<mio::osecirvvs::SerialInterval>()[indx_agegroup], 0.00015, 1e-14);
+    EXPECT_NEAR(model.parameters.get<mio::osecirvvs::SerialInterval>()[indx_agegroup], 0.15, 1e-14);
 
     model.parameters.set<mio::osecirvvs::SerialInterval>(5);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_NEAR(model.parameters.get<mio::osecirvvs::SerialInterval>()[indx_agegroup], 0.00015, 1e-14);
+    EXPECT_NEAR(model.parameters.get<mio::osecirvvs::SerialInterval>()[indx_agegroup], 0.15, 1e-14);
 
     model.parameters.set<mio::osecirvvs::TimeInfectedSymptoms>(1e-5);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_EQ(model.parameters.get<mio::osecirvvs::TimeInfectedSymptoms>()[indx_agegroup], 1e-4);
+    EXPECT_EQ(model.parameters.get<mio::osecirvvs::TimeInfectedSymptoms>()[indx_agegroup], tol_times);
 
     model.parameters.set<mio::osecirvvs::TimeInfectedSevere>(-1);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_EQ(model.parameters.get<mio::osecirvvs::TimeInfectedSevere>()[indx_agegroup], 1e-4);
+    EXPECT_EQ(model.parameters.get<mio::osecirvvs::TimeInfectedSevere>()[indx_agegroup], tol_times);
 
     model.parameters.set<mio::osecirvvs::TimeInfectedCritical>(0);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_EQ(model.parameters.get<mio::osecirvvs::TimeInfectedCritical>()[indx_agegroup], 1e-4);
+    EXPECT_EQ(model.parameters.get<mio::osecirvvs::TimeInfectedCritical>()[indx_agegroup], tol_times);
 
     model.parameters.set<mio::osecirvvs::TransmissionProbabilityOnContact>(2.0);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);

--- a/cpp/tests/test_odeseir.cpp
+++ b/cpp/tests/test_odeseir.cpp
@@ -159,6 +159,7 @@ TEST(TestSeir, check_constraints_parameters)
 
 TEST(TestSeir, apply_constraints_parameters)
 {
+    const double tol_times = 1e-1;
     mio::oseir::Model model;
     model.parameters.set<mio::oseir::TimeExposed>(5.2);
     model.parameters.set<mio::oseir::TimeInfected>(6);
@@ -170,11 +171,11 @@ TEST(TestSeir, apply_constraints_parameters)
     mio::set_log_level(mio::LogLevel::off);
     model.parameters.set<mio::oseir::TimeExposed>(-5.2);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_EQ(model.parameters.get<mio::oseir::TimeExposed>(), 1e-4);
+    EXPECT_EQ(model.parameters.get<mio::oseir::TimeExposed>(), tol_times);
 
     model.parameters.set<mio::oseir::TimeInfected>(1e-5);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);
-    EXPECT_EQ(model.parameters.get<mio::oseir::TimeInfected>(), 1e-4);
+    EXPECT_EQ(model.parameters.get<mio::oseir::TimeInfected>(), tol_times);
 
     model.parameters.set<mio::oseir::TransmissionProbabilityOnContact>(10.);
     EXPECT_EQ(model.parameters.apply_constraints(), 1);


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** made, additional Information and what the Reviewer should look out for:

- We increased the tolerance in the constraint checks to speed up the unit tests. Before, values to 1e-4 were possible which have lead to small dts.

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/DLR-SC/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/DLR-SC/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes and code coverage is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
