### PR TITLE
787 Treat Boost headers as system headers

### DIFF
--- a/cpp/cmake/BuildBoost.cmake
+++ b/cpp/cmake/BuildBoost.cmake
@@ -14,7 +14,7 @@ endif()
 # boost
 add_library(boost INTERFACE)
 add_library(Boost::boost ALIAS boost)
-target_include_directories(boost INTERFACE
+target_include_directories(boost SYSTEM INTERFACE
     $<BUILD_INTERFACE:${BOOST_DIR}>
 )
 


### PR DESCRIPTION
# Changes and Information

In CMake, set boost headers as system to ignore all warnings in boost headers.

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/DLR-SC/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/DLR-SC/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added

### Checks by code reviewer(s)

- [ ] Corresponding issue(s) is/are linked and addressed
- [ ] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [ ] Appropriate **unit tests** have been added, CI passes and code coverage is acceptable (did not decrease)
- [ ] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)

Closes #787 