### PR TITLE
753 replace Dampings::finalize() with set_automatic_cache_update()

### DIFF
--- a/cpp/memilio/epidemiology/contact_matrix.h
+++ b/cpp/memilio/epidemiology/contact_matrix.h
@@ -61,7 +61,6 @@ public:
         , m_dampings(Shape::get_shape_of(m_baseline))
     {
         assert(Shape::get_shape_of(m_minimum) == Shape::get_shape_of(m_baseline));
-        m_dampings.finalize();
     }
 
     /**
@@ -172,11 +171,12 @@ public:
     }
 
     /**
-     * update internal cache to make get_matrix_at thread safe.
+     * Enable/disable automatic cache update of the dampings.
+     * @see Dampings::set_automatic_cache_update
      */
-    void finalize()
+    void set_automatic_cache_update(bool b)
     {
-        m_dampings.finalize();
+        m_dampings.set_automatic_cache_update(b);
     }
 
     /**
@@ -372,12 +372,13 @@ public:
     }
 
     /**
-     * update internal cache to make get_matrix_at thread safe.
+     * Enable/disable automatic cache update for each contained matrix.
+     * @see Dampings::set_automatic_cache_update
      */
-    void finalize()
+    void set_automatic_cache_update(bool b)
     {
         for (auto& m : *this) {
-            m.finalize();
+            m.set_automatic_cache_update(b);
         }
     }
 

--- a/cpp/memilio/epidemiology/damping_sampling.h
+++ b/cpp/memilio/epidemiology/damping_sampling.h
@@ -255,13 +255,14 @@ private:
 template <class DampingExpression, class DampingSamplings, class F>
 void apply_dampings(DampingExpression& damping_expression, const DampingSamplings& dampings, F make_matrix)
 {
+    damping_expression.set_automatic_cache_update(false);
     for (auto& d : dampings) {
         for (auto& i : d.get_matrix_indices()) {
             auto m = make_matrix(double(d.get_value()) * d.get_group_weights());
             damping_expression[i].add_damping(m, d.get_level(), d.get_type(), d.get_time());
         }
     }
-    damping_expression.finalize();
+    damping_expression.set_automatic_cache_update(true);
 }
 
 /**

--- a/cpp/models/abm/lockdown_rules.cpp
+++ b/cpp/models/abm/lockdown_rules.cpp
@@ -31,21 +31,18 @@ void set_home_office(TimePoint t_begin, double p, MigrationParameters& params)
 {
     auto damping1 = Eigen::VectorXd::Constant(1, p);
     params.get<WorkRatio>().add_damping(damping1, SimulationTime(t_begin.days()));
-    params.get<WorkRatio>().finalize();
 }
 
 void set_school_closure(TimePoint t_begin, double p, MigrationParameters& params)
 {
     auto damping1 = Eigen::VectorXd::Constant(1, p);
     params.get<SchoolRatio>().add_damping(damping1, SimulationTime(t_begin.days()));
-    params.get<SchoolRatio>().finalize();
 }
 
 void close_social_events(TimePoint t_begin, double p, MigrationParameters& params)
 {
     auto damping1 = Eigen::VectorXd::Constant((size_t)AgeGroup::Count, p);
     params.get<SocialEventRate>().add_damping(damping1, SimulationTime(t_begin.days()));
-    params.get<SocialEventRate>().finalize();
 }
 
 } // namespace abm

--- a/cpp/tests/test_damping.cpp
+++ b/cpp/tests/test_damping.cpp
@@ -124,8 +124,6 @@ TEST(TestDampings, automatic_cache_update)
 
 #ifndef NDEBUG
     EXPECT_DEATH(dampings.get_matrix_at(2.0), "Cache is not current\\. Did you disable the automatic cache update\\?");
-#else
-    EXPECT_THAT(print_wrap(dampings.get_matrix_at(2.0)), MatrixNear((Eigen::VectorXd(2) << 0.0, 0.0).finished()));
 #endif
 
     dampings.set_automatic_cache_update(true);

--- a/cpp/tests/test_damping.cpp
+++ b/cpp/tests/test_damping.cpp
@@ -114,3 +114,21 @@ TEST(TestDampings, smoothTransitions)
     EXPECT_THAT(print_wrap(dampings.get_matrix_at(1.0)),
                 MatrixNear((dampings.get_matrix_at(0.5) + dampings.get_matrix_at(1.5)) / 2));
 }
+
+TEST(TestDampings, automatic_cache_update)
+{
+    mio::Dampings<mio::Damping<mio::ColumnVectorShape>> dampings(2);
+    auto D1 = 0.25;
+    dampings.set_automatic_cache_update(false);
+    dampings.add(D1, mio::DampingLevel(1), mio::DampingType(2), mio::SimulationTime(1.0));
+    
+#ifndef NDEBUG
+    EXPECT_DEATH(dampings.get_matrix_at(2.0), "Cache is not current\\. Did you disable the automatic cache update\\?");
+#else    
+    EXPECT_THAT(print_wrap(dampings.get_matrix_at(2.0)), MatrixNear((Eigen::VectorXd(2) << 0.0, 0.0).finished()));
+#endif
+
+    dampings.set_automatic_cache_update(true);
+
+    EXPECT_THAT(print_wrap(dampings.get_matrix_at(2.0)), MatrixNear((Eigen::VectorXd(2) << 0.25, 0.25).finished()));
+}

--- a/cpp/tests/test_damping.cpp
+++ b/cpp/tests/test_damping.cpp
@@ -121,10 +121,10 @@ TEST(TestDampings, automatic_cache_update)
     auto D1 = 0.25;
     dampings.set_automatic_cache_update(false);
     dampings.add(D1, mio::DampingLevel(1), mio::DampingType(2), mio::SimulationTime(1.0));
-    
+
 #ifndef NDEBUG
     EXPECT_DEATH(dampings.get_matrix_at(2.0), "Cache is not current\\. Did you disable the automatic cache update\\?");
-#else    
+#else
     EXPECT_THAT(print_wrap(dampings.get_matrix_at(2.0)), MatrixNear((Eigen::VectorXd(2) << 0.0, 0.0).finished()));
 #endif
 

--- a/cpp/tests/test_dynamic_npis.cpp
+++ b/cpp/tests/test_dynamic_npis.cpp
@@ -89,8 +89,8 @@ TEST(DynamicNPIs, get_active_damping)
     dampexpr.add_damping(0.4, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.4));
     dampexpr.add_damping(0.6, mio::DampingLevel(1), mio::DampingType(1), mio::SimulationTime(0.6));
     dampexpr.add_damping(0.5, mio::DampingLevel(0), mio::DampingType(1), mio::SimulationTime(0.5));
-    dampexpr.add_damping(0.7, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.7));
-    dampexpr.add_damping(0.9, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.9));
+    dampexpr.add_damping(0.4, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.7));
+    dampexpr.add_damping(0.5, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.9));
 
     auto a = mio::get_active_damping(dampexpr, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.6));
     EXPECT_EQ(print_wrap(a), print_wrap(Eigen::MatrixXd::Constant(1, 1, 0.4)));
@@ -100,6 +100,9 @@ TEST(DynamicNPIs, get_active_damping)
 
     auto c = mio::get_active_damping(dampexpr, mio::DampingLevel(1), mio::DampingType(1), mio::SimulationTime(0.4));
     EXPECT_EQ(print_wrap(c), print_wrap(Eigen::MatrixXd::Constant(1, 1, 0.0)));
+
+    auto d = mio::get_active_damping(dampexpr, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.8));
+    EXPECT_EQ(print_wrap(d), print_wrap(Eigen::MatrixXd::Constant(1, 1, 0.4)));
 }
 
 TEST(DynamicNPIs, get_active_damping_empty)
@@ -147,17 +150,17 @@ TEST(DynamicNPIs, implement)
         return (Eigen::MatrixXd(3, 1) << g(0, 0), g(1, 0), g(2, 0)).finished();
     };
 
-    dampexprs[0].add_damping(0.3, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.3));
-    dampexprs[0].add_damping(0.4, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.4));
-    dampexprs[0].add_damping(0.5, mio::DampingLevel(0), mio::DampingType(1), mio::SimulationTime(0.5));
-    dampexprs[0].add_damping(0.7, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.7));
+    dampexprs[0].add_damping(0.15, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.3));
+    dampexprs[0].add_damping(0.2, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.4));
+    dampexprs[0].add_damping(0.25, mio::DampingLevel(0), mio::DampingType(1), mio::SimulationTime(0.5));
+    dampexprs[0].add_damping(0.35, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.7));
 
-    dampexprs[1].add_damping(0.5, mio::DampingLevel(1), mio::DampingType(1), mio::SimulationTime(0.5));
-    dampexprs[1].add_damping(0.9, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.9));
+    dampexprs[1].add_damping(0.25, mio::DampingLevel(1), mio::DampingType(1), mio::SimulationTime(0.5));
+    dampexprs[1].add_damping(0.45, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.9));
 
     {
         auto dynamic_npis = std::vector<mio::DampingSampling>(
-            {mio::DampingSampling(0.8, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0), {0, 1},
+            {mio::DampingSampling(0.4, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0), {0, 1},
                                   Eigen::MatrixXd::Ones(3, 1))});
         mio::implement_dynamic_npis(dampexprs, dynamic_npis, mio::SimulationTime(0.45), mio::SimulationTime(0.6),
                                     make_mask);
@@ -166,24 +169,24 @@ TEST(DynamicNPIs, implement)
     EXPECT_THAT(
         dampexprs[0].get_dampings(),
         testing::ElementsAre(
-            Damping(0.3, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.3), 3, 1), //before npi
-            Damping(0.4, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.4), 3, 1), //before npi
-            Damping(0.8, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.45), 3, 1), //npi begins
-            Damping(0.5, mio::DampingLevel(0), mio::DampingType(1), mio::SimulationTime(0.5), 3, 1), //other type
-            Damping(0.4, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.6), 3, 1), //npi ends
-            Damping(0.7, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.7), 3, 1))); //after npi
+            Damping(0.15, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.3), 3, 1), //before npi
+            Damping(0.2, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.4), 3, 1), //before npi
+            Damping(0.4, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.45), 3, 1), //npi begins
+            Damping(0.25, mio::DampingLevel(0), mio::DampingType(1), mio::SimulationTime(0.5), 3, 1), //other type
+            Damping(0.2, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.6), 3, 1), //npi ends
+            Damping(0.35, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.7), 3, 1))); //after npi
 
     EXPECT_THAT(
         dampexprs[1].get_dampings(),
         testing::ElementsAre(
-            Damping(0.8, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.45), 3, 1), //npi begins
-            Damping(0.5, mio::DampingLevel(1), mio::DampingType(1), mio::SimulationTime(0.5), 3, 1), //other type/level
+            Damping(0.4, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.45), 3, 1), //npi begins
+            Damping(0.25, mio::DampingLevel(1), mio::DampingType(1), mio::SimulationTime(0.5), 3, 1), //other type/level
             Damping(0.0, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.6), 3, 1), //npi ends
-            Damping(0.9, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.9), 3, 1))); //after npi
+            Damping(0.45, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.9), 3, 1))); //after npi
 
     {
         auto dynamic_npis = std::vector<mio::DampingSampling>({mio::DampingSampling(
-            0.6, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0), {0}, Eigen::MatrixXd::Ones(3, 1))});
+            0.3, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0), {0}, Eigen::MatrixXd::Ones(3, 1))});
         mio::implement_dynamic_npis(dampexprs, dynamic_npis, mio::SimulationTime(0.3), mio::SimulationTime(0.9),
                                     make_mask);
     }
@@ -191,23 +194,23 @@ TEST(DynamicNPIs, implement)
     EXPECT_THAT(
         dampexprs[0].get_dampings(),
         testing::ElementsAre(
-            Damping(0.6, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.3), 3, 1), //new npi begins
-            Damping(0.8, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.45), 3,
+            Damping(0.3, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.3), 3, 1), //new npi begins
+            Damping(0.4, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.45), 3,
                     1), //old npi begins, is kept because it's bigger
-            Damping(0.5, mio::DampingLevel(0), mio::DampingType(1), mio::SimulationTime(0.5), 3, 1), //other type
-            Damping(0.6, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.6), 3,
+            Damping(0.25, mio::DampingLevel(0), mio::DampingType(1), mio::SimulationTime(0.5), 3, 1), //other type
+            Damping(0.3, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.6), 3,
                     1), //old npi ends, down to value of new npi
             Damping(
-                0.7, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.7), 3,
+                0.35, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.7), 3,
                 1))); //bigger than new npi, new npi ends at t = 0.9, but is already overwritten here by a higher value
 
     //second matrix not changed by the new npi
     EXPECT_THAT(
         dampexprs[1].get_dampings(),
-        testing::ElementsAre(Damping(0.8, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.45), 3, 1),
-                             Damping(0.5, mio::DampingLevel(1), mio::DampingType(1), mio::SimulationTime(0.5), 3, 1),
+        testing::ElementsAre(Damping(0.4, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.45), 3, 1),
+                             Damping(0.25, mio::DampingLevel(1), mio::DampingType(1), mio::SimulationTime(0.5), 3, 1),
                              Damping(0.0, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.6), 3, 1),
-                             Damping(0.9, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.9), 3, 1)));
+                             Damping(0.45, mio::DampingLevel(0), mio::DampingType(0), mio::SimulationTime(0.9), 3, 1)));
 }
 
 namespace mio_test


### PR DESCRIPTION
# Changes and Information

Removed Dampings.finalize (and related functions) and added Dampings.set_automatic_cache_update(bool). This changes the default behavior of dampings. Until now, the cache was updated when manually calling finalize or when reading from the cache. Now the cache is always updated immediately when adding dampings unless explicitly disabled. This is safer in a multithreaded environment as it is less likely that someone accidentally disables the cache or forgets to reenable it. There is an assert that checks it in debug builds.

Added a unit test for the cache. 

The new behavior also surfaced some bugs in old tests that broke the rule that the final damping after accumulation should be less than 1. Because the cache didn't use to be updated in those tests, the assert didn't get triggered. In order to not change the logic of the test (which was OK) I just halved every damping value (and the expected values) in the test.

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/DLR-SC/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/DLR-SC/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added

### Checks by code reviewer(s)

- [ ] Corresponding issue(s) is/are linked and addressed
- [ ] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [ ] Appropriate **unit tests** have been added, CI passes and code coverage is acceptable (did not decrease)
- [ ] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)

Closes #753