### PR TITLE
754 static migration rules instead of vector of rules

### DIFF
--- a/cpp/models/abm/world.h
+++ b/cpp/models/abm/world.h
@@ -179,14 +179,24 @@ public:
      */
     void use_migration_rules(bool param);
     bool use_migration_rules() const;
-    
-    bool has_location(LocationType loc)
+
+    /**
+    * @brief Check if at least one Location with a specified LocationType exists.
+    * @return True if there is at least one Location of LocationType `type`. False otherwise.
+    */
+    bool has_location(LocationType type) const
     {
-        return m_has_locations[size_t(loc)];
+        return m_has_locations[size_t(type)];
     }
 
-    template<class C = std::initializer_list<LocationType>>
-    bool has_locations(const C& location_types)
+    /**
+    * @brief Check if at least one Location of every specified LocationType exists.
+    * @tparam C A type of container of LocationType.
+    * @param location_types A container of LocationType%s.
+    * @return True if there is at least one Location of every LocationType in `location_types`. False otherwise.
+    */
+    template <class C = std::initializer_list<LocationType>>
+    bool has_locations(const C& location_types) const
     {
         return std::all_of(location_types.begin(), location_types.end(), [&](auto loc) {
             return has_location(loc);

--- a/cpp/models/abm/world.h
+++ b/cpp/models/abm/world.h
@@ -20,6 +20,7 @@
 #ifndef EPI_ABM_WORLD_H
 #define EPI_ABM_WORLD_H
 
+#include "abm/location_type.h"
 #include "abm/parameters.h"
 #include "abm/location.h"
 #include "abm/person.h"
@@ -30,6 +31,8 @@
 #include "memilio/utils/random_number_generator.h"
 #include "memilio/utils/stl_util.h"
 
+#include <bitset>
+#include <initializer_list>
 #include <vector>
 #include <memory>
 
@@ -58,9 +61,9 @@ public:
         : m_infection_parameters(params)
         , m_migration_parameters()
         , m_trip_list()
+        , m_use_migration_rules(true)
         , m_cemetery_id(add_location(LocationType::Cemetery))
     {
-        use_migration_rules(true);
     }
 
     //type is move-only for stable references of persons/locations
@@ -176,6 +179,19 @@ public:
      */
     void use_migration_rules(bool param);
     bool use_migration_rules() const;
+    
+    bool has_location(LocationType loc)
+    {
+        return m_has_locations[size_t(loc)];
+    }
+
+    template<class C = std::initializer_list<LocationType>>
+    bool has_locations(const C& location_types)
+    {
+        return std::all_of(location_types.begin(), location_types.end(), [&](auto loc) {
+            return has_location(loc);
+        });
+    }
 
     /** 
      * @brief Get the TestingStrategy.
@@ -211,16 +227,14 @@ private:
 
     std::vector<std::unique_ptr<Person>> m_persons; ///< Vector with pointers to every Person.
     std::vector<std::unique_ptr<Location>> m_locations; ///< Vector with pointers to every Location.
+    std::bitset<size_t(LocationType::Count)>
+        m_has_locations; ///< Flags for each LocationType, set if a Location of that type exists.
     TestingStrategy m_testing_strategy; ///< List of TestingScheme%s that are checked for testing.
     GlobalInfectionParameters m_infection_parameters; /** Parameters of the Infection that are the same everywhere in
     the World.*/
     MigrationParameters m_migration_parameters; ///< Parameters that describe the migration between Location%s.
     TripList m_trip_list; ///< List of all Trip%s the Person%s do.
     bool m_use_migration_rules; ///< Whether migration rules are considered.
-    std::vector<std::pair<LocationType (*)(Person::RandomNumberGenerator&, const Person&, TimePoint, TimeSpan,
-                                           const MigrationParameters&),
-                          std::vector<LocationType>>>
-        m_migration_rules; ///< Rules that govern the migration between Location%s.
     LocationId m_cemetery_id; // Central cemetery for all dead persons.
     RandomNumberGenerator m_rng; ///< Global random number generator
 };


### PR DESCRIPTION
# Changes and Information

Removed the vector that stores the migration rules. Instead call each rule statically. This improves performance significantly because the compiler knows exactly which functions are getting called.

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/DLR-SC/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/DLR-SC/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes and code coverage is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)

Closes #754 