### PR TITLE
537 silence gmock warnings

### DIFF
--- a/cpp/tests/test_dynamic_npis.cpp
+++ b/cpp/tests/test_dynamic_npis.cpp
@@ -262,8 +262,8 @@ void calculate_migration_returns(Eigen::Ref<mio::TimeSeries<double>::Vector>, co
 
 TEST(DynamicNPIs, migration)
 {
-    mio::SimulationNode<mio_test::DummySim> node_from((Eigen::VectorXd(2) << 0.0, 1.0).finished());
-    mio::SimulationNode<mio_test::DummySim> node_to((Eigen::VectorXd(2) << 0.0, 1.0).finished());
+    mio::SimulationNode<testing::NiceMock<mio_test::DummySim>> node_from((Eigen::VectorXd(2) << 0.0, 1.0).finished());
+    mio::SimulationNode<testing::NiceMock<mio_test::DummySim>> node_to((Eigen::VectorXd(2) << 0.0, 1.0).finished());
 
     auto last_state_safe = (Eigen::VectorXd(2) << 0.01, 0.99).finished();
     auto last_state_crit = (Eigen::VectorXd(2) << 0.02, 0.98).finished();

--- a/cpp/tests/test_time_series.cpp
+++ b/cpp/tests/test_time_series.cpp
@@ -322,3 +322,12 @@ TYPED_TEST(TestTimeSeries, create)
         }
     }
 }
+
+TEST(TestTimeSeries, printTo)
+{
+    //PrintTo is test code, so we don't check the exact output, just that it exists and doesn't fail
+    auto ts = mio::TimeSeries<double>::zero(3, 2);
+    std::stringstream ss;
+    PrintTo(ts, &ss);
+    ASSERT_FALSE(ss.str().empty());
+}


### PR DESCRIPTION
# Changes and Information

Silence some gmock warnings in a unit test by using NiceMock. The default implementation for `get_result` of the Mock class does the right thing, so silencing the warning is OK. 

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/DLR-SC/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/DLR-SC/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes and code coverage is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)

Close #537 